### PR TITLE
Add Express server hosting /mod-compatibility endpoint

### DIFF
--- a/commands/mod.js
+++ b/commands/mod.js
@@ -19,6 +19,7 @@ module.exports = {
   usage: '[mod name]',
   cooldown: 5,
   args: true,
+  mods: [],
 };
 
 module.exports.init = async function() {
@@ -53,6 +54,7 @@ module.exports.init = async function() {
           obs: row[5],
         };
       });
+      module.exports.mods = mods;
       var options = {
         shouldSort: true,
         tokenize: true,

--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ const config = {
   "google_email": process.env.google_email,
   "token": process.env.discord_token,
   "spreadsheet": process.env.spreadsheet,
+  "expressPort": process.env.expressPort || 3000,
   "range": "A3:F",
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
+const express = require('express');
 const Discord = require('discord.js');
-const { prefix, token } = require('./config.js');
+const { prefix, token, expressPort } = require('./config.js');
 
 const client = new Discord.Client();
 client.commands = new Discord.Collection();
@@ -88,4 +89,24 @@ client.on('message', message => {
   }
 });
 
-client.login(token);
+if (token) {
+  client.login(token);
+} else {
+  console.warn("No discord_token passed! Bot not running.");
+}
+
+const expressApp = express();
+expressApp.get('/', (req, res) => res.send('The Times 3 January 2009 Chancellor on brink of second bailout for banks'));
+expressApp.get('/mod-compatibility', (req, res) => {
+  const mods = client.commands.get('mod').mods;
+  res.send(mods.reduce((obj, mod) => {
+    const compatibility = parseInt(mod.status);
+    if (mod.steam && !isNaN(compatibility)) {
+      obj[mod.steam] = compatibility;
+    }
+    return obj;
+  }, {}));
+});
+expressApp.listen(expressPort, () => {
+  console.log(`Listening for /mod-compatibility requests on port ${expressPort}`);
+});

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/notfood/Discord-Advisor-Bot#readme",
   "dependencies": {
     "discord.js": "^11.5.1",
+    "express": "^4.17.1",
     "fuse.js": "^3.4.5",
     "googleapis": "^36.0.0"
   }


### PR DESCRIPTION
Dumps the mod compatibility dict as json:

```
{"704181221":1,"704182588":0,"705924057":4,...}
```

http://neb.nebtown.info:51412/mod-compatibility

To be used by my in-game mod list branch, to workaround Google Sheets API rate limits :)